### PR TITLE
Extra closing tag caused text files to not be viewable

### DIFF
--- a/4x3Hirez/DialogTextViewer.xml
+++ b/4x3Hirez/DialogTextViewer.xml
@@ -27,7 +27,6 @@
 			<posy>0</posy>
 			<include>DialogCloseButtonCommons</include>
 		</control>
-		</control>
 		<control type="image">
 			<posx>0</posx>
 			<posy>60</posy>


### PR DESCRIPTION
An extra </control> tag caused errors when trying to view a text file
- Removed the extraneous tag
