### PR TITLE
[cosmetics] fix settings overlap

### DIFF
--- a/4x3Hirez/SettingsCategory.xml
+++ b/4x3Hirez/SettingsCategory.xml
@@ -26,6 +26,7 @@
 		</control>
 		<control type="group">
 			<include>Window_OpenClose_Animation_Zoom</include>
+			<include>ScrollArrowsCommonsSettings</include>
 			<posx>50</posx>
 			<posy>140</posy>
 			<control type="grouplist" id="3">
@@ -45,7 +46,7 @@
 				<posx>300</posx>
 				<posy>0</posy>
 				<width>880</width>
-				<height>720</height>
+				<height>605</height>
 				<itemgap>0</itemgap>
 				<pagecontrol>60</pagecontrol>
 				<onleft>3</onleft>

--- a/4x3Hirez/includes.xml
+++ b/4x3Hirez/includes.xml
@@ -295,6 +295,27 @@
 			<animation effect="fade" time="150">Hidden</animation>
 		</control>
 	</include>
+	<include name="ScrollArrowsCommonsSettings">
+		<control type="scrollbar" id="60">
+			<posx>30r</posx>
+			<posy>0</posy>
+			<width>17</width>
+			<height>605</height>
+			<texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>
+			<texturesliderbar border="0,14,0,14">ScrollBarV_bar.png</texturesliderbar>
+			<texturesliderbarfocus border="0,14,0,14">ScrollBarV_bar_focus.png</texturesliderbarfocus>
+			<textureslidernib>ScrollBarNib.png</textureslidernib>
+			<textureslidernibfocus>ScrollBarNib.png</textureslidernibfocus>
+			<onleft>60</onleft>
+			<onright>60</onright>
+			<ondown>60</ondown>
+			<onup>60</onup>
+			<showonepage>false</showonepage>
+			<orientation>vertical</orientation>
+			<animation effect="fade" time="150">Visible</animation>
+			<animation effect="fade" time="150">Hidden</animation>
+		</control>
+	</include>
 	<include name="HomeButtonCommons">
 		<control type="button">
 			<description>Home Button</description>


### PR DESCRIPTION
settings description would overlap the settings list.

this commit also adds a scrollbar to the settings screens.
